### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ os: linux
 dist: trusty
 dotnet: 2.1
 script:
-  - dotnet build -c Release
-  - dotnet pack -c Release
+  - dotnet build src/ -c Release
+  - dotnet pack src/ --output ./ -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ os: linux
 dist: trusty
 dotnet: 2.1
 script:
+  - dotnet restore
   - dotnet build src/ -c Release
   - dotnet pack src/ --output ./ -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: csharp
+mono: none
+os: linux
+dist: trusty
+dotnet: 2.1.0
+script:
+  - dotnet build -c Release
+  - dotnet pack -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
   - cd src
   - dotnet restore
   - dotnet build -c Release
-  - dotnet pack -c Release
+  - dotnet pack --output ../ -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os: linux
 dist: trusty
 dotnet: 2.1
 script:
+  - cd src
   - dotnet restore
-  - dotnet build src/ -c Release
-  - dotnet pack src/ --output ./ -c Release
+  - dotnet build -c Release
+  - dotnet pack -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: none
 os: linux
 dist: trusty
-dotnet: 2.1.0
+dotnet: 2.1
 script:
   - dotnet build -c Release
   - dotnet pack -c Release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# spocr
+# spocr [![Build Status](https://travis-ci.org/nuetzliches/spocr.svg?branch=master)](https://travis-ci.org/nuetzliches/spocr)
+
 - Scaffolds your StoredProcedures into a C# DataContext structure. Be supriesed by many more features.
 - Simply managed by the console (ComandLineInterface/CLI)
 


### PR DESCRIPTION
Added travis open source integration for .NET Core.

Includes the following:
- dotnet restore (build will fail if there's something wrong with .NET CORE Install)
- dotnet build (fail if project can't be build)
- dotnet pack (pack the project for nuget)

TODO: 
- add tests
- add nuget account and auto-publish new version if merge into master is successful