### PR TITLE
fix(build): show warning on @UserId at wrong position for SPs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "program": "${workspaceFolder}/src/bin/Debug/netcoreapp2.1/SpocR.dll",
             // awailable commands: "create", "pull", "build", "rebuild", "remove", options: "-d|--dry-run"
             "args": [
-                "create",
+                "rebuild",
                 //"-d"
             ],
             "cwd": "${workspaceFolder}/src",

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ public Task<List<UserList>> ListAsync(CancellationToken cancellationToken = defa
 # Required .NET Core Packages for Web-API
 - Newtonsoft.Json
 - System.Data.SqlClient
+- Microsoft.Extensions.Configuration
 
 # Installation
 - Install [.NET Core 2.1](https://www.microsoft.com/net/download)

--- a/src/Contracts/Definitions.cs
+++ b/src/Contracts/Definitions.cs
@@ -95,7 +95,11 @@ namespace SpocR.Contracts
             // Returns:
             //     The part of the Name before the [Operation] starts. 
             //     e.g.: "User" from Name "UserCreate"
-            public string EntityName => _entityName ?? (_entityName = Name.Substring(0, Name.IndexOf(OperationKind.ToString())));
+            public string EntityName => _entityName 
+                ?? (_entityName = OperationKind != OperationKindEnum.Undefined 
+                    ? Name.Substring(0, Name.IndexOf(OperationKind.ToString()))
+                    : Name
+            );
             public string Suffix => _suffix ?? (_suffix = Name.Substring(Name.IndexOf(OperationKind.ToString()) + OperationKind.ToString().Length));
             public OperationKindEnum OperationKind => _operationKind != OperationKindEnum.Undefined
                 ? _operationKind


### PR DESCRIPTION
This PR fixes issue #46 

New Output after running `spocr rebuild`: 

```
...
CodeBase generated in 659 ms.
DataContextModels generated in 85 ms.
DataContextParams generated in 12 ms.
[WARNING]: The StoredProcedure [dbo].[UserList] violates the requirement: First Parameter with Name '@UserId' (this can lead to unpredictable issues)
DataContextStoredProcedures generated in 485 ms.
```